### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,21 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.12"
+    # You can also specify other tool versions:
+     nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
 
-python:
-  install:
-    - requirements: docs/requirements.txt
-    # Install our python package before building the docs
-    - method: pip
-      path: .
-
+# Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/source/conf.py
-  fail_on_warning: true
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+   fail_on_warning: true
 
-formats:
-  - pdf
-  - epub
+# Optionally build your docs in additional formats such as PDF and ePub
+ formats:
+   - pdf
+   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt


### PR DESCRIPTION
# Read the Docs configuration file for Sphinx projects # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details

# Required
version: 2

# Set the OS, Python version and other tools you might need build:
  os: ubuntu-22.04
  tools:
    python: "3.12"
    # You can also specify other tool versions:
    # nodejs: "20"
    # rust: "1.70"
    # golang: "1.20"

# Build documentation in the "docs/" directory with Sphinx sphinx:
  configuration: docs/conf.py
  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
  # builder: "dirhtml"
  # Fail on all warnings to avoid broken references
  # fail_on_warning: true

# Optionally build your docs in additional formats such as PDF and ePub # formats:
#   - pdf
#   - epub

# Optional but recommended, declare the Python requirements required # to build your documentation
# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html # python:
#   install:
#     - requirements: docs/requirements.txt