### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
   tools:
     python: "3.12"
     # You can also specify other tool versions:
-     nodejs: "20"
+    # nodejs: "20"
     # rust: "1.70"
     # golang: "1.20"
 


### PR DESCRIPTION
# Read the Docs configuration file for MkDocs projects # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details

# Required
version: 2

# Set the version of Python and other tools you might need build:
  os: ubuntu-22.04
  tools:
    python: "3.12"

mkdocs:
  configuration: mkdocs.yml

# Optionally declare the Python requirements required to build your docs python:
  install:
  - requirements: docs/requirements.txt

formats:
  - pdf
  - epub