### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,21 +1,19 @@
+# Read the Docs configuration file for MkDocs projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
+# Set the version of Python and other tools you might need
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally declare the Python requirements required to build your docs
 python:
   install:
-    - requirements: docs/requirements.txt
-    # Install our python package before building the docs
-    - method: pip
-      path: .
-
-sphinx:
-  configuration: docs/source/conf.py
-  fail_on_warning: true
-
-formats:
-  - pdf
-  - epub
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
# Read the Docs configuration file for MkDocs projects # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details

# Required
version: 2

# Set the version of Python and other tools you might need build:
  os: ubuntu-22.04
  tools:
    python: "3.12"

mkdocs:
  configuration: mkdocs.yml

# Optionally declare the Python requirements required to build your docs python:
  install:
  - requirements: docs/requirements.txt